### PR TITLE
addr hash to pass as key in hashmap

### DIFF
--- a/pytoniq_core/boc/address.py
+++ b/pytoniq_core/boc/address.py
@@ -125,4 +125,4 @@ class Address:
         return f'Address<{self.to_str()}>'
     
     def __hash__(self):
-        return int.from_bytes(self.hash_part, "big")
+        return int.from_bytes(self.hash_part, "big") + self.wc


### PR DESCRIPTION
without hash function TypeError: unhashable type: 'Address' occurs 