### PR TITLE
More accurate counting of available space during MessageAny serialization

### DIFF
--- a/pytoniq_core/tlb/transaction.py
+++ b/pytoniq_core/tlb/transaction.py
@@ -159,7 +159,7 @@ class MessageAny(TlbScheme):
         builder = Builder().store_cell(self.info.serialize())
         if self.init:
             builder.store_bit(1)  # maybe true
-            if len(self.init.serialize().bits) <= builder.available_bits and len(self.init.serialize().refs) <= builder.available_refs:
+            if len(self.init.serialize().bits) <= (builder.available_bits - 2) and len(self.init.serialize().refs) <= builder.available_refs:
                 builder.store_bit(0)  # Either left
                 builder.store_cell(self.init.serialize())
             else:
@@ -167,7 +167,7 @@ class MessageAny(TlbScheme):
                 builder.store_ref(self.init.serialize())
         else:
             builder.store_bit(0)  # maybe false
-        if len(self.body.bits) <= builder.available_bits and len(self.body.refs) <= builder.available_refs:
+        if len(self.body.bits) <= (builder.available_bits - 1) and len(self.body.refs) <= builder.available_refs:
             builder.store_bit(0)  # Either left
             builder.store_cell(self.body)
         else:

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="pytoniq-core",
-    version="0.1.27",
+    version="0.1.29",
     author="Maksim Kurbatov",
     author_email="cyrbatoff@gmail.com",
     description="TON Blockchain SDK",

--- a/tests/test_MessageAny_serialize.py
+++ b/tests/test_MessageAny_serialize.py
@@ -1,0 +1,12 @@
+from pytoniq_core.tlb import MessageAny, ExternalMsgInfo, InternalMsgInfo, CurrencyCollection
+from pytoniq_core.tlb.block import ExtraCurrencyCollection
+from pytoniq_core.boc import Address, Cell, Builder
+
+from pytoniq_core.tlb.account import StateInit
+
+def test_ser():
+    test_addr = Address("EQDLjulz89Z90ReVL-a9TTKc5ON0PVhCHVGx3pkvzX5Qzt3S")
+    info = ExternalMsgInfo(test_addr, test_addr, 0)
+    body = Builder().store_bits([1,] * 482).end_cell()
+    message = MessageAny(info = info, init = None, body = body)
+    message.serialize()


### PR DESCRIPTION
This fix fixes some situations where body in MessageAny can not be serialized:
- After inline-serialization of 'init' should be one bit left for 'Either bit' for the body
- 'body' should be inline-serialized only if there are available more or equal than (len(body.bits) + 1) bits