### PR TITLE
Fix integer overflow in vmstack serialization

### DIFF
--- a/pytoniq_core/tlb/vm_stack.py
+++ b/pytoniq_core/tlb/vm_stack.py
@@ -68,7 +68,7 @@ class VmStackValue(TlbScheme):
         if value is None:
             builder.store_bytes(b'\x00')
         elif isinstance(value, int):
-            if value.bit_length() <= 64:
+            if value.bit_length() < 64:
                 builder.store_bytes(b'\x01')
                 builder.store_int(value, 64)
             else:


### PR DESCRIPTION
Python's `int.bit_length()` method doesn't include the bit needed for the sign. So if `value.bit_length() == 64` it actually needs 65 bits.

At the moment, serializing a number with exactly 64 bits in length will raise an exception in the bitarray package. For example:
```python
VmStackValue.serialize(10_000_000_000_000_000_000)
```

Will raise the exception [here](https://github.com/ilanschnell/bitarray/blob/1a1dac8162394cf79b17a72ca8de3c3f7e20db6a/bitarray/util.py#L258):
```python
def int2ba(__i, length=None, endian=None, signed=False):
    ....
    if signed:
        m = 1 << (length - 1)
        if not (-m <= __i < m):
            raise OverflowError("signed integer not in range(%d, %d), "
                                "got %d" % (-m, m, __i))
```

The fix is simply to:
```diff
-if value.bit_length() <= 64:
+if value.bit_length() < 64:
    builder.store_bytes(b'\x01')
    builder.store_int(value, 64)
```
