### PR TITLE
Add a way to serialize TLB Objects to json

### DIFF
--- a/pytoniq_core/boc/address.py
+++ b/pytoniq_core/boc/address.py
@@ -117,7 +117,7 @@ class Address:
     #     return self.to_str()
 
     def __eq__(self, other: "Address"):
-        return self.wc == other.wc and self.hash_part == other.hash_part
+        return self.wc == other.wc and self.hash_part == other.hash_part and self.anycast == other.anycast
 
     def __repr__(self):
         if self.anycast is not None:

--- a/pytoniq_core/boc/address.py
+++ b/pytoniq_core/boc/address.py
@@ -127,6 +127,15 @@ class Address:
     def __hash__(self):
         return int.from_bytes(self.hash_part, "big") + self.wc
 
+    def __json__(self):
+        if self.anycast is not None:
+            # to_str ignores anycast, that can be dangerous as default strategy
+            # thus fallback to __repr__
+            return self.__repr__()
+        # flags like is_bounceable, is_test_only, as well as url-safeness
+        # are application dependent thus in json use not user-friendly form
+        return self.to_str(is_user_friendly=False)
+
 
 class ExternalAddress:
     def __init__(self, address: typing.Union[int, str, bytes, None], length: int = None):

--- a/pytoniq_core/tlb/tlb.py
+++ b/pytoniq_core/tlb/tlb.py
@@ -4,7 +4,7 @@ from abc import ABC, abstractmethod
 
 
 def is_builtin_class_instance(obj):
-    return obj.__class__.__module__ == '__builtins__'
+    return obj.__class__.__module__ in ['__builtins__', 'builtins']
 
 
 class TlbError(Exception):
@@ -32,3 +32,16 @@ class TlbScheme(ABC):
         # return s + '\t' * t + '>' + '\n'
         return f'< Tl-B {self.__class__.__name__} {" ".join([i + ": " + j.__repr__() for i, j in self.__dict__.items()])} >'
         # TODO beautiful repr
+
+    def __json__(self):
+        # if __json__ is not defined for a class, it will return str(obj)
+        ret = {}
+        for i, j in self.__dict__.items():
+            if is_builtin_class_instance(j):
+                ret[i] = j
+            elif hasattr(j, '__json__'):
+                ret[i] = j.__json__()
+            else:
+                ret[i] = str(j)
+        ret['type'] = self.__class__.__name__
+        return ret


### PR DESCRIPTION
* Provide __json__()  method to make TLB Objects json serializable
* Do the same for Address
* Fix equality check for Addresses, include anycast info into comparison


P.S.  To make it work, json encoder monkey patching is needed, at least for now, still it is quite usable
```
from json import JSONEncoder
def wrapped_default(self, obj):
    return getattr(obj.__class__, "__json__", wrapped_default.default)(obj)
wrapped_default.default = JSONEncoder().default
   
# apply the patch
JSONEncoder.original_default = JSONEncoder.default
JSONEncoder.default = wrapped_default
```